### PR TITLE
Added ability to undo underline by selecting around <u> tags

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -39,14 +39,22 @@ export default class Underline extends Plugin {
 
     var beforeText = editor.getRange(Cursor(fos - 3), Cursor(tos - len));
     var afterText = editor.getRange(Cursor(fos + len), Cursor(tos + 4));
+    var startText = editor.getRange(Cursor(fos), Cursor(fos + 3));
+    var endText = editor.getRange(Cursor(tos - 4), Cursor(tos));
 
     if (beforeText === "<u>" && afterText === "</u>") {
-      //=> undo underline
+      //=> undo underline (inside selection)
 
       editor.setSelection(Cursor(fos - 3), Cursor(tos + 4));
       editor.replaceSelection(`${selectedText}`);
       // re-select
       editor.setSelection(Cursor(fos - 3), Cursor(tos - 3));
+    } else if (startText === "<u>" && endText === "</u>") {
+      //=> undo underline (outside selection)
+      
+      editor.replaceSelection(editor.getRange(Cursor(fos + 3), Cursor(tos - 4)));
+      // re-select
+      editor.setSelection(Cursor(fos), Cursor(tos - 7));
     } else {
       //=> do underline
 


### PR DESCRIPTION
Currently you can only undo an underline by selecting inside the <u></u> tags. After accidentally selecting around the outside of the tags a few times, I thought maybe it wouldn't hurt to add that as an option as well.