### PR TITLE
Add command icons

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ export default class Underline extends Plugin {
     this.addCommand({
       id: "toggle-underline-tag",
       name: "Toggle underline tag",
+      icon: "lucide-underline",
       editorCallback: (editor: Editor, view: MarkdownView) =>
         this.wrapper(editor, view),
       hotkeys: [
@@ -18,6 +19,7 @@ export default class Underline extends Plugin {
     this.addCommand({
       id: "toggle-center-tag",
       name: "Toggle center tag",
+      icon: "lucide-align-center",
       editorCallback: (editor: Editor, view: MarkdownView) =>
         this.wrapper(editor, view, "<center>", "</center>"),
       // hotkeys: [
@@ -31,6 +33,7 @@ export default class Underline extends Plugin {
     this.addCommand({
       id: "toggle-link-heading",
       name: "Toggle a link to heading in the same file",
+      icon: "lucide-link",
       editorCallback: (editor: Editor, view: MarkdownView) =>
         this.wrapper(editor, view, "[[#", "]]"),
       // hotkeys: [
@@ -43,6 +46,7 @@ export default class Underline extends Plugin {
     this.addCommand({
       id: "toggle-link-block",
       name: "Toggle a link to block in the same file",
+      icon: "lucide-link",
       editorCallback: (editor: Editor, view: MarkdownView) =>
         this.wrapper(editor, view, "[[#^", "]]"),
       // hotkeys: [


### PR DESCRIPTION
This is an issue that's been bugging me for a long time that turned out to be super easy to fix. Previously, when adding the Underline and Center commands to the mobile toolbars, it just shows a "?". Now, these two commands, as well as the other two "Link to heading" and "Link to block" commands, all have command icons. No extra files are needed for this - it uses Obsidian's built-in Lucide icons.

Before...

![BEFORE](https://github.com/user-attachments/assets/6f2bdf59-1995-4810-8a6a-743f23fa3dbe)

vs after...

![AFTER](https://github.com/user-attachments/assets/572dedd2-b76a-4130-98ac-d5ab53d8bcc2)
